### PR TITLE
Focus on last tab in dashboard projects

### DIFF
--- a/src/components/project/DashboardProjectsManagement.vue
+++ b/src/components/project/DashboardProjectsManagement.vue
@@ -42,7 +42,7 @@ const initTabs = () => {
         name: obj.name,
         commission: obj.id
     }))
-    if (tabs.value.length) tab.value = tabs.value[0].name
+    if (tabs.value.length) tab.value = tabs.value.at(-1).name
 }
 
 onMounted(async () => {


### PR DESCRIPTION
Bonjour,

Je suis à la fois membre d’association et de élu à la CAPE. Je me permet de faire une PR ici, n'ayant pas accès au dépôt qui est en privé sur le Gitlab de l'Unistra.

Sur la partie gestion des commissions, j'ai été dérangé par le fait de toujours retomber sur la première commission et non pas la dernière, qui est souvent celle qui nous intéresse le plus. Je propose donc ce petit changement afin de correspondre à ce comportement.